### PR TITLE
Added invariant culture for stringify type serialization

### DIFF
--- a/src/Acr.Settings.Interface/AbstractSettings.cs
+++ b/src/Acr.Settings.Interface/AbstractSettings.cs
@@ -92,7 +92,8 @@ namespace Acr.Settings {
 
 
 		protected virtual void OnChanged(SettingChangeEventArgs args) {
-			this.Changed?.Invoke(this, args);
+            if (this.Changed != null)
+			    this.Changed.Invoke(this, args);
             var native = this.NativeValues();
             this.List = new ReadOnlyDictionary<string, string>(native);
 		}
@@ -101,9 +102,11 @@ namespace Acr.Settings {
         protected virtual string Serialize(Type type, object value) {
             if (type == typeof(string))
                 return (string)value;
-
-            if (this.IsStringifyType(type))
-                return value.ToString();
+            
+            if (this.IsStringifyType(type)) {
+                var formattable = value as IFormattable;
+                return formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
+            }
 
             return JsonConvert.SerializeObject(value);
         }
@@ -114,7 +117,7 @@ namespace Acr.Settings {
                 return value;
 
             if (this.IsStringifyType(type))
-                return Convert.ChangeType(value, type);
+                return Convert.ChangeType(value, type, System.Globalization.CultureInfo.InvariantCulture);
 
             return JsonConvert.DeserializeObject(value, type);
         }


### PR DESCRIPTION
If the end users switches culture during the install of the app, it may crash since decimal types will be either comma or period seperated depending on the culture.

The additional change the null check on the event, is a favor for my cross compilation issues, what does the $ mean on the strings?