### PR TITLE
Missing SAVE() from Windows Phone implementation

### DIFF
--- a/src/Acr.Settings.WindowsPhone/SettingsImpl.cs
+++ b/src/Acr.Settings.WindowsPhone/SettingsImpl.cs
@@ -42,11 +42,13 @@ namespace Acr.Settings {
         protected override void NativeSet(Type type, string key, object value) {
             var @string = this.Serialize(type, value);
             this.container[key] = @string;
+            this.container.Save();
         }
 
 
         protected override void NativeRemove(string key) {
             this.container.Remove(key);
+            this.container.Save();
         }
 
 


### PR DESCRIPTION
The WP implementation does not actually persist the settings, since the save function is not called on changes (set and delete)