### PR TITLE
Json explicit typenamehandling

### DIFF
--- a/src/Acr.Settings.Interface/AbstractSettings.cs
+++ b/src/Acr.Settings.Interface/AbstractSettings.cs
@@ -108,7 +108,7 @@ namespace Acr.Settings {
                 return formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
             }
 
-            return JsonConvert.SerializeObject(value, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All });
+            return JsonConvert.SerializeObject(value, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
         }
 
 
@@ -119,7 +119,7 @@ namespace Acr.Settings {
             if (this.IsStringifyType(type))
                 return Convert.ChangeType(value, type, System.Globalization.CultureInfo.InvariantCulture);
 
-            return JsonConvert.DeserializeObject(value, type, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All});
+            return JsonConvert.DeserializeObject(value, type, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.Auto });
         }
 
 

--- a/src/Acr.Settings.Interface/AbstractSettings.cs
+++ b/src/Acr.Settings.Interface/AbstractSettings.cs
@@ -108,7 +108,7 @@ namespace Acr.Settings {
                 return formattable.ToString(null, System.Globalization.CultureInfo.InvariantCulture);
             }
 
-            return JsonConvert.SerializeObject(value);
+            return JsonConvert.SerializeObject(value, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All });
         }
 
 
@@ -119,7 +119,7 @@ namespace Acr.Settings {
             if (this.IsStringifyType(type))
                 return Convert.ChangeType(value, type, System.Globalization.CultureInfo.InvariantCulture);
 
-            return JsonConvert.DeserializeObject(value, type);
+            return JsonConvert.DeserializeObject(value, type, new JsonSerializerSettings() { TypeNameHandling = TypeNameHandling.All});
         }
 
 


### PR DESCRIPTION
I almost feel guilty of sending yet another one, but I just discovered that really complex types will not deserialize correcly if json settings has not set the typenamehandling to AUTO.